### PR TITLE
feat(cli): enable pnp to gatsby-cli and repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 packages/*/yarn.lock
 packages/*/package-lock.json
+.pnp*
 
 # Logs
 logs

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 *.min.js
 **/node_modules/**
 flow-typed
+.pnp/*
 
 # webfont demo styles
 **/specimen_files

--- a/integration-tests/jest.config.js
+++ b/integration-tests/jest.config.js
@@ -9,4 +9,5 @@ module.exports = {
     `__tests__/fixtures`,
   ],
   transform: { "^.+\\.js$": `<rootDir>/jest-transformer.js` },
+  resolver: require.resolve(`jest-pnp-resolver`),
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -42,4 +42,5 @@ module.exports = {
     },
   },
   collectCoverageFrom: coverageDirs,
+  resolver: require.resolve(`jest-pnp-resolver`),
 }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,12 @@
     "flow-bin": "^0.42.0",
     "fs-extra": "^7.0.0",
     "glob": "^7.1.1",
-    "husky": "1.1.1",
+    "husky": "1.1.4",
     "jest": "^23.5.0",
     "jest-cli": "^23.5.0",
+    "jest-environment-jsdom": "^23.4.0",
+    "jest-pnp-resolver": "^1.0.2",
+    "jest-resolve": "^23.6.0",
     "lerna": "^3.3.0",
     "lint-staged": "^8.0.4",
     "npm-run-all": "4.1.2",
@@ -86,5 +89,8 @@
   },
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "installConfig": {
+    "pnp": true
+  }
 }

--- a/packages/gatsby-cli/src/__tests__
+++ b/packages/gatsby-cli/src/__tests__
@@ -1,0 +1,22 @@
+jest.mock(`fs-exists-cached`);
+jest.mock(`execa`);
+const existsSync = require(`fs-exists-cached`).sync
+const execa = require(`execa`);
+
+const Starter = require(`../init-starter`)
+
+describe(`Starter`, () => {
+  it(`installs as normal without any flags`, async () => {
+    execa.mockReturnValue(Promise.resolve())
+    await Starter(`gatsbyjs/gatsby-starter-default`, { rootPath: __dirname })
+
+    expect(execa).toHaveBeenCalledWith('yarnpkg', [], { stdio: `inherit` })
+  });
+
+  it(`install uses pnp when --use-pnp is true`, async () => {
+    execa.mockReturnValue(Promise.resolve())
+    await Starter(`gatsbyjs/gatsby-starter-default`, { usePnp: true, rootPath: __dirname })
+
+    expect(execa).toHaveBeenCalledWith('yarnpkg', ['--enable-pnp'], { stdio: `inherit` })
+  });
+});

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -296,12 +296,16 @@ module.exports = (argv, handlers) => {
 
   return cli
     .command({
-      command: `new [rootPath] [starter]`,
+      command: `new [rootPath] [starter] [options]`,
       desc: `Create new Gatsby project.`,
+      builder: yargs =>
+        yargs.option(`use-pnp`, {
+          type: `boolean`,
+        }),
       handler: handlerP(
-        ({ rootPath, starter = `gatsbyjs/gatsby-starter-default` }) => {
+        ({ rootPath, starter = `gatsbyjs/gatsby-starter-default`, usePnp }) => {
           const initStarter = require(`./init-starter`)
-          return initStarter(starter, { rootPath })
+          return initStarter(starter, { rootPath, usePnp })
         }
       ),
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7601,19 +7601,6 @@ execa@^0.8.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
-  integrity sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -9810,13 +9797,13 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-1.1.1.tgz#7179043184f68a4d1ffc975cbd1c6132ef1fd7b3"
-  integrity sha512-D8ly8eIZdWzWVG4mh4apaX1PP47uLSaN8CS0RyuuLtHJ20Gt6Ccky5pSecaPsqxNzQj0zon3x6QX/0kCc5/TOQ==
+husky@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.1.4.tgz#92f61383527d2571e9586234e5864356bfaceaa9"
+  integrity sha512-cZjGpS7qsaBSo3fOMUuR7erQloX3l5XzL1v/RkIqU6zrQImDdU70z5Re9fGDp7+kbYlM2EtS4aYMlahBeiCUGw==
   dependencies:
     cosmiconfig "^5.0.6"
-    execa "^0.9.0"
+    execa "^1.0.0"
     find-up "^3.0.0"
     get-stdin "^6.0.0"
     is-ci "^1.2.1"
@@ -11122,6 +11109,11 @@ jest-mock@^23.2.0:
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
   integrity sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=
 
+jest-pnp-resolver@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.0.2.tgz#470384ae9ea31f72136db52618aa4010ff23b715"
+  integrity sha512-H2DvUlwdMedNGv4FOliPDnxani6ATWy70xe2eckGJgkLoMaWzRPqpSlc5ShqX0Ltk5OhRQvPQY2LLZPOpgcc7g==
+
 jest-regex-util@^23.3.0:
   version "23.3.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.3.0.tgz#5f86729547c2785c4002ceaa8f849fe8ca471bc5"
@@ -11139,6 +11131,15 @@ jest-resolve@^23.5.0:
   version "23.5.0"
   resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.5.0.tgz#3b8e7f67e84598f0caf63d1530bd8534a189d0e6"
   integrity sha512-CRPc0ebG3baNKz/QicIy5rGfzYpMNm8AjEl/tDQhehq/QC4ttyauZdvAXel3qo+4Gri9ljajnxW+hWyxZbbcnQ==
+  dependencies:
+    browser-resolve "^1.11.3"
+    chalk "^2.0.1"
+    realpath-native "^1.0.0"
+
+jest-resolve@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.6.0.tgz#cf1d1a24ce7ee7b23d661c33ba2150f3aebfa0ae"
+  integrity sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==
   dependencies:
     browser-resolve "^1.11.3"
     chalk "^2.0.1"


### PR DESCRIPTION
<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
This PR adds a --use-pnp flag to the cli to enable support for yarn Plug'n'play. I couldn't really find much documentation about it but in fact it uses https://pnpm.js.org/ under the hood.

### how it works:
`gatsby new gatsby-site --use-pnp` it will trigger `yarnpkg --enable-pnp` if supported. You'll need at least yarn 1.12.0.

I added a small unit test to make sure yarnpkg is called with --enable-pnp.

Besides adding PNP to the cli I also upgraded the whole repo to have it enabled by default.
(note changing the repo to pnp I would have done in another PR because now I've fixed 2 features into one). IMO it's not yet ready for prime time.

Benchmark cli 
* without pnp:
![image](https://user-images.githubusercontent.com/1120926/48642002-e42c0580-e9db-11e8-80f2-6c2e00f31dd9.png)


* with pnp:
![image](https://user-images.githubusercontent.com/1120926/48644731-d24e6080-e9e3-11e8-9222-186955030e54.png)
